### PR TITLE
Fix division by scalar

### DIFF
--- a/src/rational.jl
+++ b/src/rational.jl
@@ -32,7 +32,11 @@ function (/)(num, den::APL)
 end
 # Polynomial divided by coefficient is a polynomial not a rational polynomial
 # (1/den) * num would not be correct in case of noncommutative coefficients
-(/)(num::APL, den) = num * (1 / den)
+function (/)(num::APL{T}, den::S) where {T,S}
+    R = Base.promote_op(/, T, S)
+    num * inv(convert(R, den))
+end
+
 
 function (+)(r::RationalPoly, s::RationalPoly)
     (r.num*s.den + r.den*s.num) / (r.den * s.den)

--- a/src/rational.jl
+++ b/src/rational.jl
@@ -32,11 +32,8 @@ function (/)(num, den::APL)
 end
 # Polynomial divided by coefficient is a polynomial not a rational polynomial
 # (1/den) * num would not be correct in case of noncommutative coefficients
-function (/)(num::APL{T}, den::S) where {T,S}
-    R = Base.promote_op(/, T, S)
-    num * inv(convert(R, den))
-end
-
+(/)(num::APL, den) = polynomial(map(t -> coefficient(t)/den * monomial(t), terms(num)), SortedUniqState())
+    
 
 function (+)(r::RationalPoly, s::RationalPoly)
     (r.num*s.den + r.den*s.num) / (r.den * s.den)


### PR DESCRIPTION
This fixes a problem when working with high precision coefficients. 

Before `one(BigFloat)*x/3` would be the same as `one(BigFloat)*x*(1/3)`, which would loose precision.