### PR TITLE
handle printing of non-number coefficients

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -6,7 +6,6 @@ if VERSION < v"0.7.0-DEV.1144" # Define `isone` for base types JuliaLang/julia#2
     isone(x::T) where T = x == one(T)
 end
 
-
 function show(io::IO, m::AbstractMonomial)
     if isconstant(m)
         print(io, '1')

--- a/src/show.jl
+++ b/src/show.jl
@@ -6,6 +6,7 @@ if VERSION < v"0.7.0-DEV.1144" # Define `isone` for base types JuliaLang/julia#2
     isone(x::T) where T = x == one(T)
 end
 
+
 function show(io::IO, m::AbstractMonomial)
     if isconstant(m)
         print(io, '1')
@@ -21,6 +22,8 @@ function show(io::IO, m::AbstractMonomial)
     end
 end
 
+should_print_coefficient(x) = true  # By default, just print all coefficients
+should_print_coefficient(x::Number) = !isone(x) # For numbers, we omit any "one" coefficients
 print_coefficient(io::IO, coeff::Real) = print(io, coeff)
 print_coefficient(io::IO, coeff) = print(io, "(", coeff, ")")
 
@@ -28,8 +31,8 @@ function Base.show(io::IO, t::AbstractTerm)
     if isconstant(t)
         print_coefficient(io, coefficient(t))
     else
-        if !isone(coefficient(t))
-            if isone(-coefficient(t))
+        if should_print_coefficient(coefficient(t))
+            if !should_print_coefficient(-coefficient(t))
                 print(io, '-')
             else
                 print_coefficient(io, coefficient(t))

--- a/test/show.jl
+++ b/test/show.jl
@@ -24,5 +24,5 @@
     @test sprint(show, -(1.0 + 3.1im) * z*x) == "(-1.0 - 3.1im)xz"
     @test sprint(show, x^2 + (1.0 + 3.1im) * x) == "x^2 + (1.0 + 3.1im)x"
     @test sprint(show, x^2 - (1.0 + 3.1im) * x) == "x^2 + (-1.0 - 3.1im)x"
-    @test sprint(show, [1.0, 2.0] * x == "([1.0, 2.0])x")
+    @test sprint(show, [1.0, 2.0] * x) == "([1.0, 2.0])x"
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -24,4 +24,5 @@
     @test sprint(show, -(1.0 + 3.1im) * z*x) == "(-1.0 - 3.1im)xz"
     @test sprint(show, x^2 + (1.0 + 3.1im) * x) == "x^2 + (1.0 + 3.1im)x"
     @test sprint(show, x^2 - (1.0 + 3.1im) * x) == "x^2 + (-1.0 - 3.1im)x"
+    @test sprint(show, [1.0, 2.0] * x == "([1.0, 2.0])x")
 end


### PR DESCRIPTION
Polynomials with vector coefficients work just fine, but they can't be displayed because we end up trying to call `one(::Vector)` just to decide whether to print that coefficient. This PR just makes sure we only use `isone` for `Number`s and just print everything else. 