### PR TITLE
Add docs as a seperate build step on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,16 @@ matrix:
 notifications:
   email: false
 
+jobs:
+  include:
+    - stage: "Documentation"
+      julia: 1.0
+      os: linux
+      script:
+        - julia --project=docs/ -e 'using Pkg; Pkg.instantiate(); Pkg.add(PackageSpec(path=pwd()))'
+        - julia --project=docs/ docs/make.jl
+      after_success: skip
+
 after_success:
   # push coverage results to Coveralls
   - julia -e 'using Pkg; Pkg.add("Coverage"); import MultivariatePolynomials; cd(joinpath(dirname(pathof(MultivariatePolynomials)), "..")); using Coverage; Coveralls.submit(Coveralls.process_folder()); Codecov.submit(Codecov.process_folder())'
-  # push coverage results to Codecov
-  - julia -e 'using Pkg; Pkg.add("Documenter")'
-  - julia -e 'import MultivariatePolynomials; cd(joinpath(dirname(pathof(MultivariatePolynomials)), "..")); include(joinpath("docs", "make.jl"))'

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+MultivariatePolynomials = "102ac46a-7ee4-5c85-9060-abc95bfdeaa3"
+
+[compat]
+Documenter = "^0.19.6"


### PR DESCRIPTION
This is to avoid #97 again. This let's travis fail if it is not possible to build the docs.