### PR TITLE
Avoid defining conversion to Any

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -6,7 +6,7 @@ Base.convert(::Type{P}, p::APL) where P<:AbstractPolynomial = P(polynomial(p))
 
 Base.convert(::Type{Any}, p::APL) = p
 # Conversion polynomial -> scalar
-function Base.convert(::Type{S}, p::APL) where {S}
+function Base.convert(S::Type{<:Union{Number, T}}, p::APL{T}) where T
     s = zero(S)
     for t in terms(p)
         if !isconstant(t)

--- a/test/polynomial.jl
+++ b/test/polynomial.jl
@@ -133,4 +133,11 @@ const MP = MultivariatePolynomials
         @test coefficients(f) == [7, 4, -5, 4]
         @test monomials(f) == monovec([x^2*z^2, x*y^2*z, x^3, z^2])
     end
+
+    @testset "Convertion" begin
+        p = 2.5x + 1 - 2.5x
+        @test convert(Int, p) == 1
+        @test convert(typeof(p), p) === p
+        @test convert(Union{Nothing, typeof(p)}, p) === p
+    end
 end


### PR DESCRIPTION
This conversion has already caused trouble. It is now making conversion to `Union{Nothing, ...}` fail. Enough is enough :-P