### PR TITLE
Fix differentiate of AbstractArrays

### DIFF
--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -40,11 +40,11 @@ differentiate(p::RationalPoly, v::AbstractVariable) = (differentiate(p.num, v) *
 const ARPL = Union{APL, RationalPoly}
 
 function differentiate(ps::AbstractArray{PT}, xs::AbstractArray) where {PT <: ARPL}
-    differentiate.(reshape(ps, (1, size(ps)...)), reshape(xs, :))
+    differentiate.(reshape(ps, (size(ps)..., 1)), reshape(xs, 1, :))
 end
 
 function differentiate(ps::AbstractArray{PT}, xs::Tuple) where {PT <: ARPL}
-    differentiate.(reshape(ps, (1, size(ps)...)), xs)
+    differentiate(ps, collect(xs))
 end
 
 

--- a/src/differentiation.jl
+++ b/src/differentiation.jl
@@ -17,6 +17,8 @@ will help the compiler infer the return type.
     differentiate(p::AbstractArray{<:AbstractPolynomialLike, N}, vs, deg::Union{Int, Val}=1) where N
 
 Differentiate the polynomials in `p` by the variables of the vector or tuple of variable `vs` and return an array of dimension `N+deg`.
+If `p` is an `AbstractVector` this returns the Jacobian of `p` where the i-th row containts the partial
+derivaties of `p[i]`.
 
 ### Examples
 
@@ -25,6 +27,7 @@ p = 3x^2*y + x + 2y + 1
 differentiate(p, x) # should return 6xy + 1
 differentiate(p, x, Val{1}()) # equivalent to the above
 differentiate(p, (x, y)) # should return [6xy+1, 3x^2+1]
+differentiate( [x^2+y, z^2+4x], [x, y, z]) # should return [2x 1 0; 4 0 2z]
 ```
 """
 function differentiate end

--- a/test/differentiation.jl
+++ b/test/differentiation.jl
@@ -1,5 +1,5 @@
 @testset "Differentiation" begin
-    Mod.@polyvar x y
+    Mod.@polyvar x y z
     @test differentiate(3, y) == 0
     @test differentiate.([x, y], y) == [0, 1]
     @test differentiate([x, y], (x, y)) == Matrix(1.0I, 2, 2) # TODO: this can be just `I` on v0.7 and above
@@ -33,6 +33,10 @@
     p = differentiate(2x^2 + 3x*y^2 + 4y^3 + 2.0, (x, y), 2)
     @test isa(p, Matrix{<:AbstractPolynomial{Float64}})
     @test p == [4.0 6.0y; 6.0y 6.0x+24.0y]
+
+    f = [x^2+y, z^2+4x]
+    @test differentiate(f, [x, y, z]) == [2x 1 0; 4 0 2z]
+    @test differentiate(f, (x, y, z)) == [2x 1 0; 4 0 2z]
 
     @testset "differentiation with Val{}" begin
         @test @inferred(differentiate(x, x, Val{0}())) == x


### PR DESCRIPTION
Previously `differentiate([x+y,y+z],[x,y,z])` would return a 3 x 2 
matrix instead of the more commonly used 2 x 3 matrix.