### PR TITLE
Add coefficient(p, vars, monomial)

### DIFF
--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -55,6 +55,7 @@ polynomialtype
 terms
 nterms
 coefficients
+coefficient(p::AbstractPolynomialLike, vars, m::AbstractMonomialLike)
 monomials
 mindegree
 maxdegree

--- a/src/term.jl
+++ b/src/term.jl
@@ -72,6 +72,33 @@ function coefficient(p::AbstractPolynomialLike{T}, m::AbstractMonomialLike) wher
 end
 
 """
+    coefficient(p::AbstractPolynomialLike, m::AbstractMonomialLike, vars)::AbstractPolynomialLike
+
+Returns the coefficient of the monomial `m` of the polynomial `p` considered as a polynomial in variables
+`vars`.
+
+### Example
+Calling `coefficient((a+b)x^2+2x+y*x^2, x^2, [x,y])` should return `a+b`.
+Calling `coefficient((a+b)x^2+2x+y*x^2, x^2, [x])` should return `a+b+y`.
+"""
+function coefficient(f::APL, m::AbstractMonomialLike, vars)
+    coeff = zero(f)
+    for t in terms(f)
+        match = true
+        for v in vars
+            if degree(t, v) != degree(m, v)
+                match = false
+                break
+            end
+        end
+        match || continue
+
+        coeff += coefficient(t) * (_div(monomial(t), m))
+    end
+    coeff
+end
+
+"""
     coefficient(p::AbstractPolynomialLike)
 
 Returns the coefficient type of `p`.

--- a/test/polynomial.jl
+++ b/test/polynomial.jl
@@ -51,6 +51,10 @@ const MP = MultivariatePolynomials
     @test coefficient(2x + 4y^2 + 3, y^2) == 4
     @test coefficient(2x + 4y^2 + 3, x^2) == 0
 
+    Mod.@polyvar a b
+    @test coefficient((2a + b)x^2 + 2y^2 + 3, x^2, (x,y)) == 2a + b
+    @test coefficient((2a + b)x^2 + 2y^2 + 3x^2*y, x^2, (x,)) == 2a + b + 3y
+
     @test (@inferred 2x^2*y + 0.0x*y) == 2x^2*y
     @test (@inferred 0.0x^2*y + 3x*y) == 3x*y
 


### PR DESCRIPTION
Assume the situation that you have two polynomials in variables x, y and parameters a, b. Now I want to compare coefficients of these polynomial by considering them as polynomials in C[a,b][x,y].
So far this is quite annoying to do. This should make it easier by introducing
```
coefficient((2a + b)x^2 + 2y^2 + 3, x^2, [x,y]) == 2a + b
```