### PR TITLE
Zero and one should return RationalPoly

### DIFF
--- a/src/rational.jl
+++ b/src/rational.jl
@@ -66,7 +66,7 @@ Base.:*(r::RationalPoly, p::APL)          = (r.num * p) / r.den
 Base.:*(α, r::RationalPoly)               = (α * r.num) / r.den
 Base.:*(r::RationalPoly, α)               = (r.num * α) / r.den
 
-Base.zero(::RationalPoly{NT}) where {NT} = zero(NT) / one(NT)
+Base.zero(r::RationalPoly) = zero(typeof(r))
 Base.zero(::Type{RationalPoly{NT, DT}}) where {NT, DT} = zero(NT) / one(DT)
-Base.one(::RationalPoly{NT}) where {NT} = one(NT) / one(NT)
+Base.one(r::RationalPoly) = one(typeof(r))
 Base.one(::Type{RationalPoly{NT, DT}}) where {NT, DT} = one(NT) / one(DT)

--- a/src/rational.jl
+++ b/src/rational.jl
@@ -66,7 +66,7 @@ Base.:*(r::RationalPoly, p::APL)          = (r.num * p) / r.den
 Base.:*(α, r::RationalPoly)               = (α * r.num) / r.den
 Base.:*(r::RationalPoly, α)               = (r.num * α) / r.den
 
-Base.zero(::RationalPoly{NT}) where {NT} = zero(NT)
-Base.zero(::Type{RationalPoly{NT, DT}}) where {NT, DT} = zero(NT)
-Base.one(::RationalPoly{NT}) where {NT} = one(NT)
-Base.one(::Type{RationalPoly{NT, DT}}) where {NT, DT} = one(NT)
+Base.zero(::RationalPoly{NT}) where {NT} = zero(NT) / one(NT)
+Base.zero(::Type{RationalPoly{NT, DT}}) where {NT, DT} = zero(NT) / one(DT)
+Base.one(::RationalPoly{NT}) where {NT} = one(NT) / one(NT)
+Base.one(::Type{RationalPoly{NT, DT}}) where {NT, DT} = one(NT) / one(DT)

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -28,7 +28,12 @@
     @test x / x^2 == inv(x)
     @test isone(((x+1) / (x-1)) / ((x+1) / (x-1)))
     @test ((x+1)^2 / (x-1)) / ((x+1) / (x-1)) == x+1
-    RType = typeof(x+1/x)
+    poly = x+1/x
+    RType = typeof(poly)
     @test RType(true) == one(RType)
     @test RType(false) == zero(RType)
+    @test one(RType) isa RationalPoly
+    @test zero(RType) isa RationalPoly
+    @test one(poly) isa RationalPoly
+    @test zero(poly) isa RationalPoly
 end

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -28,12 +28,12 @@
     @test x / x^2 == inv(x)
     @test isone(((x+1) / (x-1)) / ((x+1) / (x-1)))
     @test ((x+1)^2 / (x-1)) / ((x+1) / (x-1)) == x+1
-    poly = x+1/x
+    poly = (x+1)/(x+2.0)
     RType = typeof(poly)
     @test RType(true) == one(RType)
     @test RType(false) == zero(RType)
-    @test one(RType) isa RationalPoly
-    @test zero(RType) isa RationalPoly
-    @test one(poly) isa RationalPoly
-    @test zero(poly) isa RationalPoly
+    @test one(RType) isa RType
+    @test zero(RType) isa RType
+    @test one(poly) isa RType
+    @test zero(poly) isa RType
 end


### PR DESCRIPTION
`zero(RationalPoly)` and `one(RationalPoly)` should actually return an object of type `RationalPoly`. `zero(Rational{Int})` also returns `0//1` and not `0`.