### PR TITLE
Update to MA v0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "MultivariatePolynomials"
 uuid = "102ac46a-7ee4-5c85-9060-abc95bfdeaa3"
 license = "MIT"
 repo = "https://github.com/JuliaAlgebra/MultivariatePolynomials.jl"
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -11,7 +11,7 @@ MutableArithmetics = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
 
 [compat]
 DataStructures = "0.17"
-MutableArithmetics = "0.1.1"
+MutableArithmetics = "0.2"
 julia = "1"
 
 [extras]

--- a/test/show.jl
+++ b/test/show.jl
@@ -25,7 +25,6 @@
     @test sprint(show, -(1.0 + 3.1im) * z*x) == "(-1.0 - 3.1im)xz"
     @test sprint(show, x^2 + (1.0 + 3.1im) * x) == "x² + (1.0 + 3.1im)x"
     @test sprint(show, x^2 - (1.0 + 3.1im) * x) == "x² + (-1.0 - 3.1im)x"
-    @test sprint(show, [1.0, 2.0] * x) == "([1.0, 2.0])x"
 
     Mod.@polyvar x[0:9]
     @test sprint(show, sum(i*x[i]^i for i=1:10)) == "10x₉¹⁰ + 9x₈⁹ + 8x₇⁸ + 7x₆⁷ + 6x₅⁶ + 5x₄⁵ + 4x₃⁴ + 3x₂³ + 2x₁² + x₀"


### PR DESCRIPTION
**BREAKING CHANGE**
Multiplying a polynomials by a matrix of constants now give a matrix of polynomials instead of a polynomial with matrix coefficients.
It was already the case for matrix of polynomials with https://github.com/JuliaAlgebra/MultivariatePolynomials.jl/pull/105