### PR TITLE
Simplify promotion

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -42,7 +42,10 @@ end
 function Base.convert(TT::Type{<:AbstractTerm{T}}, t::AbstractTerm) where T
     return convert(TT, convert(T, coefficient(t)) * monomial(t))
 end
-function Base.convert(::Type{T}, t::T) where T <: AbstractTerm
+
+# Base.convert(::Type{T}, t::T) where {T <: AbstractTerm} is ambiguous with above method.
+# we need the following:
+function Base.convert(::Type{TT}, t::TT) where {T, TT <: AbstractTerm{T}}
     return t
 end
 

--- a/src/hash.jl
+++ b/src/hash.jl
@@ -1,26 +1,22 @@
-_hashpowers(u::UInt) = u
-function _hashpowers(u::UInt, power::Tuple, powers...)
-    if iszero(power[2])
-        _hashpowers(u, powers...)
-    else
-        _hashpowers(hash(power, u), powers...)
-    end
-end
 function Base.hash(m::AbstractMonomial, u::UInt)
     nnz = count(!iszero, exponents(m))
     if iszero(nnz)
         hash(1, u)
     elseif isone(nnz) && isone(degree(m))
+        # We want the has of `m` to match the hash of `variable(m)`
+        # so we ignore the exponent one.
         hash(variable(m), u)
     else
-        _hashpowers(u, powers(m)...)
+        reduce((u, power) -> iszero(power[2]) ? u : hash(power, u), powers(m), init=u)
     end
 end
 
 function Base.hash(t::AbstractTerm, u::UInt)
     if iszero(t)
         hash(0, u)
-    elseif coefficient(t) == 1
+    elseif isone(coefficient(t))
+        # We want the has of `t` to match the hash of `monomial(t)`
+        # so we ignore the coefficient one.
         hash(monomial(t), u)
     else
         hash(monomial(t), hash(coefficient(t), u))


### PR DESCRIPTION
I guess promotion was written when `monomialtype`, `termtype` and `polynomialtype` did not existed yet.
With these, it can be vastly simplified. In fact, with this new implementation, we can get rid of the `promote.jl` file of DynamicPolynomials entirely. By the way, until then, we will loose some coverage.

@tweisser You should like it!