### PR TITLE
Update det.jl

### DIFF
--- a/src/det.jl
+++ b/src/det.jl
@@ -2,7 +2,9 @@ function LinearAlgebra.det(M::Matrix{<:AbstractPolynomialLike})
     m = size(M)[1]
     if m > 2
         return sum((-1)^(i-1) * M[i,1] * LinearAlgebra.det(M[1:end .!= i, 2:end]) for i in 1:m)
-    else
+    elseif m == 2
         return M[1,1] * M[2,2] - M[2,1] * M[1,2]
+    else
+        return M[1,1]
     end
 end


### PR DESCRIPTION
det(M) fails if M is a 1x1 matrix, in which case it should just return the one element of that matrix. This might seem like a strange application of det but arises naturally when e.g. computing minors of a matrix.