### PR TITLE
Narrow `convert` methods to reduce invalidations

### DIFF
--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -60,9 +60,8 @@ function Base.convert(::Type{T}, p::AbstractPolynomial) where T <: AbstractTermL
 end
 
 MA.scaling(p::AbstractPolynomialLike{T}) where {T} = convert(T, p)
-Base.convert(::Type{Any}, p::APL) = p
 # Conversion polynomial -> scalar
-function Base.convert(S::Type{<:Union{Number, T}}, p::APL{T}) where T
+function scalarize(::Type{S}, p::APL) where S
     s = zero(S)
     for t in terms(p)
         if !isconstant(t)
@@ -73,5 +72,6 @@ function Base.convert(S::Type{<:Union{Number, T}}, p::APL{T}) where T
     end
     s
 end
+Base.convert(::Type{T}, p::APL) where T<:Number = scalarize(T, p)
 
 Base.convert(::Type{PT}, p::PT) where {PT<:APL} = p


### PR DESCRIPTION
This package caused >1000 invalidations for DifferentialEquations.
The main problem is a pair of `convert` methods: one is redundant with
a method in Base (and needlessly invalidates some code),
and another intersected with signatures like
`convert(Base.SHA1, ::Any)` and other crazy types.
The reason is because the `T` in `APL{T}` is completely unconstrained,
and consequently it's possible in principle for it to be a
`REPLTerminal` or a `Module` or whatever. It didn't seem as if that were
the real intent of the convert method, but I'm just guessing that this won't break anything.

I have not run the full tests locally but :crossed_fingers: 

CC @ChrisRackauckas

Some background in another package: https://github.com/JuliaData/CategoricalArrays.jl/issues/177