### PR TITLE
Fixed promote rule bug

### DIFF
--- a/src/promote.jl
+++ b/src/promote.jl
@@ -26,7 +26,6 @@ end
 function promote_rule_constant(::Type{S}, PT::Type{<:APL{T}}) where {S, T}
     return polynomialtype(PT, promote_type(S, T))
 end
-Base.promote_rule(::Type{PT}, ::Type{T}) where {T, PT<:APL} = promote_rule_constant(T, PT)
 Base.promote_rule(::Type{T}, ::Type{PT}) where {T, PT<:APL} = promote_rule_constant(T, PT)
 # Resolve method ambiguity with Base:
 Base.promote_rule(::Type{Any}, ::Type{<:APL}) = Any


### PR DESCRIPTION
Related to [this issue](https://github.com/JuliaAlgebra/DynamicPolynomials.jl/issues/94). The generic `promote_rule` in question is provided symmetrically (as far as I'm aware `promote_type` takes care of that), but the specialisation to `T=Any` is only provided in one direction. This fixes the problem I was having.