### PR TITLE
Zero-allocation isone

### DIFF
--- a/src/comparison.jl
+++ b/src/comparison.jl
@@ -5,6 +5,13 @@ Base.iszero(m::AbstractMonomial) = false
 Base.iszero(t::AbstractTerm) = iszero(coefficient(t))
 Base.iszero(t::AbstractPolynomial) = iszero(nterms(t))
 
+Base.isone(v::AbstractVariable) = false
+Base.isone(m::AbstractMonomial) = isconstant(m)
+Base.isone(t::AbstractTerm) = isone(coefficient(t)) && isconstant(monomial(t))
+function Base.isone(p::AbstractPolynomial)
+    return isone(nterms(p)) && isone(first(terms(p)))
+end
+
 # See https://github.com/blegat/MultivariatePolynomials.jl/issues/22
 # avoids the call to be transfered to left_constant_eq
 Base.:(==)(α::Nothing, x::APL) = false

--- a/test/allocations.jl
+++ b/test/allocations.jl
@@ -1,5 +1,4 @@
 module TestAllocations
-
 include("utils.jl")
 
 function runtests()
@@ -85,6 +84,12 @@ function test_isapproxzero()
     end
     alloc_test(0) do
         isapproxzero(q; ztol = 1e-8)
+    end
+    alloc_test(0) do
+        iszero(q)
+    end
+    alloc_test(0) do
+        isone(q)
     end
 end
 


### PR DESCRIPTION
Part of https://github.com/JuliaAlgebra/MultivariatePolynomials.jl/issues/194

## Int64

### Benchmark 0

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 487.985 ns |         17 |   1.22 KiB |
| DynamicPolynomials |   6.362 μs |        199 |  10.98 KiB |
|   TypedPolynomials | 319.654 ns |         13 |  928 bytes |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 474.658 ns |         16 |   1.14 KiB |
| DynamicPolynomials |   6.417 μs |        194 |  10.66 KiB |
|   TypedPolynomials | 301.902 ns |         12 |  848 bytes |


### Benchmark 1

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 135.594 μs |       2029 |   2.11 MiB |
| DynamicPolynomials |   1.106 ms |      24312 |   3.30 MiB |
|   TypedPolynomials | 122.991 μs |       1334 |   2.26 MiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 140.808 μs |       1976 |   2.10 MiB |
| DynamicPolynomials |   1.133 ms |      24028 |   3.28 MiB |
|   TypedPolynomials | 122.591 μs |       1281 |   2.26 MiB |


### Benchmark 2

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   5.197 μs |        284 |  45.66 KiB |
| DynamicPolynomials |  54.764 μs |       1993 | 161.52 KiB |
|   TypedPolynomials |  13.814 μs |        331 |  81.55 KiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   5.388 μs |        282 |  45.50 KiB |
| DynamicPolynomials |  56.052 μs |       1979 | 160.55 KiB |
|   TypedPolynomials |  13.478 μs |        329 |  81.38 KiB |


### Benchmark 3

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 678.457 μs |      31447 |  17.63 MiB |
| DynamicPolynomials |   6.123 ms |     157668 |  25.91 MiB |
|   TypedPolynomials | 389.729 μs |       6750 |  25.04 MiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 707.457 μs |      31439 |  17.63 MiB |
| DynamicPolynomials |   6.215 ms |     156563 |  25.83 MiB |
|   TypedPolynomials | 390.848 μs |       6742 |  25.04 MiB |


## BigInt

### Benchmark 0

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   1.136 μs |         53 |   1.85 KiB |
| DynamicPolynomials |   7.260 μs |        241 |  11.71 KiB |
|   TypedPolynomials | 948.111 ns |         49 |   1.54 KiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   1.062 μs |         50 |   1.73 KiB |
| DynamicPolynomials |   7.118 μs |        234 |  11.34 KiB |
|   TypedPolynomials | 867.320 ns |         46 |   1.42 KiB |


### Benchmark 1

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 442.077 μs |      15097 |   1.95 MiB |
| DynamicPolynomials |   1.176 ms |      35718 |   3.08 MiB |
|   TypedPolynomials | 451.565 μs |      14300 |   2.10 MiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 436.290 μs |      14936 |   1.94 MiB |
| DynamicPolynomials |   1.239 ms |      35358 |   3.06 MiB |
|   TypedPolynomials | 441.870 μs |      14139 |   2.09 MiB |


### Benchmark 2

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |  10.459 μs |        450 |  48.73 KiB |
| DynamicPolynomials |  59.635 μs |       2207 | 166.03 KiB |
|   TypedPolynomials |  20.989 μs |        464 |  83.84 KiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   9.859 μs |        438 |  48.38 KiB |
| DynamicPolynomials |  61.897 μs |       2183 | 164.87 KiB |
|   TypedPolynomials |  20.753 μs |        452 |  83.48 KiB |


### Benchmark 3

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   2.611 ms |      84307 |  18.53 MiB |
| DynamicPolynomials |   7.346 ms |     205494 |  26.83 MiB |
|   TypedPolynomials |   3.194 ms |      59562 |  25.94 MiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   2.559 ms |      82161 |  18.49 MiB |
| DynamicPolynomials |   7.211 ms |     202251 |  26.71 MiB |
|   TypedPolynomials |   3.124 ms |      57416 |  25.89 MiB |


## Rational{BigInt}

### Benchmark 0

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   3.277 μs |        238 |   6.39 KiB |
| DynamicPolynomials |   8.669 μs |        397 |  15.48 KiB |
|   TypedPolynomials |   3.123 μs |        234 |   6.08 KiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   3.114 μs |        233 |   6.23 KiB |
| DynamicPolynomials |   8.093 μs |        388 |  15.06 KiB |
|   TypedPolynomials |   2.987 μs |        229 |   5.92 KiB |


### Benchmark 1

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   1.633 ms |      76735 |   4.22 MiB |
| DynamicPolynomials |   2.411 ms |      90365 |   5.33 MiB |
|   TypedPolynomials |   1.705 ms |      76099 |   4.38 MiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   1.619 ms |      76491 |   4.21 MiB |
| DynamicPolynomials |   2.365 ms |      89933 |   5.31 MiB |
|   TypedPolynomials |   1.621 ms |      75855 |   4.37 MiB |


### Benchmark 2

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |  19.585 μs |       1047 |  81.35 KiB |
| DynamicPolynomials |  73.855 μs |       2918 | 202.84 KiB |
|   TypedPolynomials |  29.112 μs |       1057 | 116.60 KiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |  18.793 μs |       1025 |  80.80 KiB |
| DynamicPolynomials |  71.722 μs |       2884 | 201.46 KiB |
|   TypedPolynomials |  27.907 μs |       1035 | 116.04 KiB |


### Benchmark 3

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   6.432 ms |     246642 |  31.21 MiB |
| DynamicPolynomials |  12.249 ms |     344839 |  38.97 MiB |
|   TypedPolynomials |   7.929 ms |     219835 |  38.67 MiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   5.781 ms |     242358 |  31.13 MiB |
| DynamicPolynomials |  11.797 ms |     339458 |  38.81 MiB |
|   TypedPolynomials |   7.177 ms |     215551 |  38.59 MiB |