### PR TITLE
Shortcut for dividing by one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         shell: julia --project=@. {0}
         run: |
           using Pkg
-          Pkg.add(PackageSpec(name="DynamicPolynomials", rev="bl/mutable_rem"))
+          Pkg.add(PackageSpec(name="DynamicPolynomials", rev="bl/mapexponents"))
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/docs/src/division.md
+++ b/docs/src/division.md
@@ -12,6 +12,7 @@ The `divrem` function returns ``(q, r)``.
 
 ```@docs
 divides
+div_multiple
 pseudo_rem
 rem_or_pseudo_rem
 ```

--- a/src/default_polynomial.jl
+++ b/src/default_polynomial.jl
@@ -323,7 +323,8 @@ function mapexponents!(f, p::Polynomial, m::AbstractMonomialLike)
     return p
 end
 function mapexponents(f, p::Polynomial, m::AbstractMonomialLike)
-    return mapexponents!(f, MA.mutable_copy(p), m)
+    P = MA.promote_operation(*, typeof(p), typeof(m))
+    return mapexponents!(f, MA.mutable_copy(convert(P, p)), m)
 end
 
 function MA.operate!(::typeof(zero), p::Polynomial)

--- a/src/default_polynomial.jl
+++ b/src/default_polynomial.jl
@@ -315,14 +315,14 @@ function MA.operate!(::typeof(*), p::Polynomial, t::AbstractTermLike)
     end
     return p
 end
-function mapexponents!(f, p::Polynomial, m::AbstractMonomial)
+function mapexponents!(f, p::Polynomial, m::AbstractMonomialLike)
     for i in eachindex(p.terms)
         t = p.terms[i]
         p.terms[i] = term(coefficient(t), mapexponents(f, monomial(t), m))
     end
     return p
 end
-function mapexponents(f, p::Polynomial, m::AbstractMonomial)
+function mapexponents(f, p::Polynomial, m::AbstractMonomialLike)
     return mapexponents!(f, MA.mutable_copy(p), m)
 end
 

--- a/src/default_polynomial.jl
+++ b/src/default_polynomial.jl
@@ -323,7 +323,7 @@ function mapexponents!(f, p::Polynomial, m::AbstractMonomial)
     return p
 end
 function mapexponents(f, p::Polynomial, m::AbstractMonomial)
-    return mapexponents(f, MA.mutable_copy(p), m, MA.IsMutable())
+    return mapexponents!(f, MA.mutable_copy(p), m)
 end
 
 function MA.operate!(::typeof(zero), p::Polynomial)

--- a/src/default_polynomial.jl
+++ b/src/default_polynomial.jl
@@ -289,7 +289,7 @@ end
 function MA.buffer_for(op::MA.AddSubMul, ::Type{<:Polynomial{S}}, ::Type{<:AbstractTermLike{T}}, ::Type{<:Polynomial{U}}) where {S,T,U}
     return MA.buffer_for(op, S, T, U)
 end
-function MA.buffered_operate!(buffer::Polynomial, op::MA.AddSubMul, p::Polynomial, t::AbstractTermLike, q::Polynomial)
+function MA.buffered_operate!(buffer, op::MA.AddSubMul, p::Polynomial, t::AbstractTermLike, q::Polynomial)
     return _polynomial_merge!(op, p, t, q, buffer)
 end
 

--- a/src/default_polynomial.jl
+++ b/src/default_polynomial.jl
@@ -315,14 +315,14 @@ function MA.operate!(::typeof(*), p::Polynomial, t::AbstractTermLike)
     end
     return p
 end
-function mapexponents(f, p::Polynomial, m::AbstractMonomial, ::MA.IsMutable)
+function mapexponents!(f, p::Polynomial, m::AbstractMonomial)
     for i in eachindex(p.terms)
         t = p.terms[i]
         p.terms[i] = term(coefficient(t), mapexponents(f, monomial(t), m))
     end
     return p
 end
-function mapexponents(f, p::Polynomial, m::AbstractMonomial, ::MA.IsNotMutable)
+function mapexponents(f, p::Polynomial, m::AbstractMonomial)
     return mapexponents(f, MA.mutable_copy(p), m, MA.IsMutable())
 end
 

--- a/src/division.jl
+++ b/src/division.jl
@@ -67,19 +67,19 @@ function div_multiple(t1::AbstractTermLike, t2::AbstractTermLike, m1::MA.Mutable
 end
 function right_constant_div_multiple(f::APL, g, mf::MA.MutableTrait=MA.IsNotMutable())
     if isone(g)
-        return f
+        return _copy(f, mf)
     end
     return mapcoefficients(coef -> div_multiple(coef, g, mf), f, mf; nonzero = true)
 end
 function div_multiple(f::APL, g::AbstractMonomialLike, mf::MA.MutableTrait=MA.IsNotMutable())
     if isconstant(g)
-        return f
+        return _copy(f, mf)
     end
     return mapexponents(-, f, g, mf)
 end
 function div_multiple(f::APL, g::AbstractTermLike, mf::MA.MutableTrait=MA.IsNotMutable())
-    f = right_constant_div_multiple(f, coefficient(g))
-    return div_multiple(f, monomial(g))
+    f = right_constant_div_multiple(f, coefficient(g), mf)
+    return div_multiple(f, monomial(g), MA.IsMutable())
 end
 function div_multiple(f::APL, g::APL, mf::MA.MutableTrait=MA.IsNotMutable())
     lt = leadingterm(g)

--- a/src/division.jl
+++ b/src/division.jl
@@ -1,4 +1,4 @@
-export divides, pseudo_rem, rem_or_pseudo_rem
+export divides, div_multiple, pseudo_rem, rem_or_pseudo_rem
 
 function Base.round(p::APL; args...)
     # round(0.1) is zero so we cannot use `mapcoefficientsnz`

--- a/src/gcd.jl
+++ b/src/gcd.jl
@@ -390,7 +390,7 @@ function flatten_variable!(::Type{TT}, poly::APL) where {TT<:AbstractTerm}
             push!(ts, _t * m)
         end
     end
-    return polynomial!(ts)
+    return polynomial!(ts, UniqState())
 end
 
 _polynomial(ts, state, ::MA.IsNotMutable) = polynomial(ts, state)

--- a/src/gcd.jl
+++ b/src/gcd.jl
@@ -521,7 +521,10 @@ function univariate_gcd(::UFD, p1::APL, p2::APL, algo::AbstractUnivariateGCDAlgo
     pp = primitive_univariate_gcd!(f1, f2, algo)
     gg = _gcd(g1, g2, algo, MA.IsMutable(), MA.IsMutable())#::MA.promote_operation(gcd, typeof(g1), typeof(g2))
     # Multiply each coefficient by the gcd of the contents.
-    return mapcoefficients!(Base.Fix1(*, gg), pp, nonzero = true)
+    if !isone(gg)
+        MA.operate!(right_constant_mult, pp, gg)
+    end
+    return pp
 end
 
 function univariate_gcd(::Field, p1::APL, p2::APL, algo::AbstractUnivariateGCDAlgorithm, m1::MA.MutableTrait, m2::MA.MutableTrait)
@@ -652,5 +655,5 @@ Addison-Wesley Professional. Third edition.
 """
 function primitive_part_content(p, algo::AbstractUnivariateGCDAlgorithm, mutability::MA.MutableTrait)
     g = content(p, algo, MA.IsNotMutable())
-    return mapcoefficients(Base.Fix2(_div, g), p, mutability; nonzero = true), g
+    return right_constant_div_multiple(p, g, mutability), g
 end

--- a/src/monomial.jl
+++ b/src/monomial.jl
@@ -130,7 +130,7 @@ If ``m_1 = \\prod x^{\\alpha_i}`` and ``m_2 = \\prod x^{\\beta_i}`` then it retu
 
 ### Examples
 
-The multiplication `m1 * m2` is equivalent to `mapexponents(+, m1, m2)`, the unsafe division `_div(m1, m2)` is equivalent to `mapexponents(-, m1, m2)`, `gcd(m1, m2)` is equivalent to `mapexponents(min, m1, m2)`, `lcm(m1, m2)` is equivalent to `mapexponents(max, m1, m2)`.
+The multiplication `m1 * m2` is equivalent to `mapexponents(+, m1, m2)`, the unsafe division `div_multiple(m1, m2)` is equivalent to `mapexponents(-, m1, m2)`, `gcd(m1, m2)` is equivalent to `mapexponents(min, m1, m2)`, `lcm(m1, m2)` is equivalent to `mapexponents(max, m1, m2)`.
 """
 mapexponents(f, m1::AbstractMonomialLike, m2::AbstractMonomialLike) = mapexponents(f, monomial(m1), monomial(m2))
 

--- a/src/monomial.jl
+++ b/src/monomial.jl
@@ -137,6 +137,9 @@ mapexponents(f, m1::AbstractMonomialLike, m2::AbstractMonomialLike) = mapexponen
 function mapexponents_to! end
 function mapexponents! end
 
+mapexponents(f, a, b, ::MA.IsMutable) = mapexponents!(f, a, b)
+mapexponents(f, a, b, ::MA.IsNotMutable) = mapexponents(f, a, b)
+
 Base.one(::Type{TT}) where {TT<:AbstractMonomialLike} = constantmonomial(TT)
 Base.one(t::AbstractMonomialLike) = constantmonomial(t)
 MA.promote_operation(::typeof(one), MT::Type{<:AbstractMonomialLike}) = monomialtype(MT)

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -363,7 +363,7 @@ function MA.buffered_operate_to!(buffer::AbstractPolynomial, output::AbstractPol
     product = MA.operate_to!!(buffer, *, y, z, args...)
     return MA.operate_to!(output, MA.add_sub_op(op), x, product)
 end
-function MA.buffered_operate!(buffer::AbstractPolynomial, op::MA.AddSubMul, x::AbstractPolynomial, y, z, args::Vararg{Any, N}) where N
+function MA.buffered_operate!(buffer, op::MA.AddSubMul, x::AbstractPolynomial, y, z, args::Vararg{Any, N}) where N
     product = MA.operate_to!!(buffer, *, y, z, args...)
     return MA.operate!(MA.add_sub_op(op), x, product)
 end

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -271,6 +271,8 @@ Base.:*(m::AbstractMonomialLike, t::AbstractTermLike) = term(coefficient(t), m *
 Base.:*(t::AbstractTermLike, m::AbstractMonomialLike) = term(coefficient(t), monomial(t) * m)
 Base.:*(t1::AbstractTermLike, t2::AbstractTermLike) = term(coefficient(t1) * coefficient(t2), monomial(t1) * monomial(t2))
 
+MA.operate!(::typeof(*), p::APL, t::AbstractMonomialLike) = mapexponents!(+, p, t)
+Base.:*(p::APL, t::AbstractMonomialLike) = mapexponents(+, p, t)
 Base.:*(t::AbstractTermLike, p::APL) = polynomial!(map(te -> t * te, terms(p)))
 Base.:*(p::APL, t::AbstractTermLike) = polynomial!(map(te -> te * t, terms(p)))
 Base.:*(p::APL, q::APL) = polynomial(p) * polynomial(q)

--- a/src/term.jl
+++ b/src/term.jl
@@ -102,7 +102,7 @@ function coefficient(f::APL, m::AbstractMonomialLike, vars)
         end
         match || continue
 
-        coeff += term(coefficient(t), _div(monomial(t), m))
+        coeff += term(coefficient(t), div_multiple(monomial(t), m))
     end
     coeff
 end

--- a/test/monomial.jl
+++ b/test/monomial.jl
@@ -81,7 +81,7 @@ end
 
     @test monic(x^2) == x^2
 
-    @test MP._div(2x^2*y[1]^3, x*y[1]^2) == 2x*y[1]
+    @test MP.div_multiple(2x^2*y[1]^3, x*y[1]^2) == 2x*y[1]
 
     @test transpose(x) == x
     @test adjoint(x) == x


### PR DESCRIPTION
Part of https://github.com/JuliaAlgebra/MultivariatePolynomials.jl/issues/194

Closes https://github.com/JuliaAlgebra/MultivariatePolynomials.jl/pull/207
Closes https://github.com/JuliaAlgebra/MultivariatePolynomials.jl/pull/201



## Int64

### Benchmark 0

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 358.810 ns |          8 |  400 bytes |
| DynamicPolynomials |   6.579 μs |        196 |  10.81 KiB |
|   TypedPolynomials | 170.237 ns |          4 |  336 bytes |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 317.813 ns |          6 |  272 bytes |
| DynamicPolynomials |   5.072 μs |        170 |   9.62 KiB |
|   TypedPolynomials | 117.847 ns |          2 |  208 bytes |


### Benchmark 1

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 132.809 μs |       1904 |   2.10 MiB |
| DynamicPolynomials |   1.166 ms |      24080 |   3.28 MiB |
|   TypedPolynomials | 124.154 μs |       1125 |   2.25 MiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 122.177 μs |       1316 | 468.48 KiB |
| DynamicPolynomials | 692.039 μs |      15658 |   1.24 MiB |
|   TypedPolynomials |  97.478 μs |        502 | 473.70 KiB |


### Benchmark 2

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   4.770 μs |        263 |  43.88 KiB |
| DynamicPolynomials |  55.238 μs |       1967 | 160.36 KiB |
|   TypedPolynomials |   5.576 μs |        188 |  74.64 KiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   3.761 μs |        218 |   8.31 KiB |
| DynamicPolynomials |  31.402 μs |       1361 |  92.11 KiB |
|   TypedPolynomials |   4.284 μs |        137 |   6.09 KiB |


### Benchmark 3

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 677.469 μs |      31351 |  17.62 MiB |
| DynamicPolynomials |   6.198 ms |     156645 |  25.84 MiB |
|   TypedPolynomials | 372.314 μs |       6414 |  25.02 MiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 461.465 μs |      26515 |   1.02 MiB |
| DynamicPolynomials |   2.307 ms |      89587 |   6.01 MiB |
|   TypedPolynomials |  92.893 μs |        547 | 353.50 KiB |


## BigInt

### Benchmark 0

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 931.929 ns |         42 | 1008 bytes |
| DynamicPolynomials |   6.983 μs |        236 |  11.50 KiB |
|   TypedPolynomials | 724.700 ns |         38 |  944 bytes |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 750.315 ns |         34 |  784 bytes |
| DynamicPolynomials |   5.634 μs |        202 |  10.19 KiB |
|   TypedPolynomials | 555.119 ns |         30 |  720 bytes |


### Benchmark 1

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 438.317 μs |      14864 |   1.93 MiB |
| DynamicPolynomials |   1.216 ms |      35406 |   3.07 MiB |
|   TypedPolynomials | 430.715 μs |      13983 |   2.08 MiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 338.276 μs |      12454 | 1001.43 KiB |
| DynamicPolynomials | 880.820 μs |      27690 |   1.85 MiB |
|   TypedPolynomials | 324.824 μs |      11554 | 1004.15 KiB |


### Benchmark 2

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   9.882 μs |        419 |  46.76 KiB |
| DynamicPolynomials |  61.901 μs |       2167 | 164.78 KiB |
|   TypedPolynomials |  12.040 μs |        311 |  76.74 KiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   5.636 μs |        307 |   9.92 KiB |
| DynamicPolynomials |  35.949 μs |       1471 |  95.04 KiB |
|   TypedPolynomials |   5.281 μs |        197 |   6.98 KiB |


### Benchmark 3

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   2.633 ms |      82073 |  18.48 MiB |
| DynamicPolynomials |   7.521 ms |     202263 |  26.72 MiB |
|   TypedPolynomials |   3.141 ms |      57088 |  25.88 MiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials | 945.529 μs |      59541 |   1.54 MiB |
| DynamicPolynomials |   2.873 ms |     111267 |   6.50 MiB |
|   TypedPolynomials | 515.503 μs |      33525 | 885.83 KiB |


## Rational{BigInt}

### Benchmark 0

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   3.026 μs |        225 |   5.48 KiB |
| DynamicPolynomials |   8.217 μs |        390 |  15.22 KiB |
|   TypedPolynomials |   2.861 μs |        221 |   5.42 KiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   2.932 μs |        217 |   5.33 KiB |
| DynamicPolynomials |   8.069 μs |        386 |  15.14 KiB |
|   TypedPolynomials |   2.792 μs |        213 |   5.27 KiB |


### Benchmark 1

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   1.673 ms |      76435 |   4.21 MiB |
| DynamicPolynomials |   2.346 ms |      89963 |   5.32 MiB |
|   TypedPolynomials |   1.679 ms |      75715 |   4.37 MiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   1.445 ms |      68042 |   2.67 MiB |
| DynamicPolynomials |   1.997 ms |      77748 |   3.53 MiB |
|   TypedPolynomials |   1.446 ms |      67322 |   2.68 MiB |


### Benchmark 2

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |  18.776 μs |       1006 |  79.23 KiB |
| DynamicPolynomials |  75.952 μs |       2847 | 200.82 KiB |
|   TypedPolynomials |  20.142 μs |        894 | 109.32 KiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |  10.845 μs |        692 |  20.28 KiB |
| DynamicPolynomials |  45.825 μs |       1968 | 108.00 KiB |
|   TypedPolynomials |  10.151 μs |        580 |  17.30 KiB |


### Benchmark 3

Before

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   6.140 ms |     242270 |  31.12 MiB |
| DynamicPolynomials |  12.206 ms |     339036 |  38.81 MiB |
|   TypedPolynomials |   7.747 ms |     215223 |  38.57 MiB |

After

|                    |       Time |      Alloc |     Memory |
|--------------------|------------|------------|------------|
|    SIMDPolynomials |   2.562 ms |     163028 |   4.71 MiB |
| DynamicPolynomials |   5.302 ms |     243218 |   9.64 MiB |
|   TypedPolynomials |   2.083 ms |     135981 |   4.01 MiB |
