### PR TITLE
Fix ambiguity arising in SumOfSquares and PolyJuMP

### DIFF
--- a/src/default_term.jl
+++ b/src/default_term.jl
@@ -110,6 +110,14 @@ function MA.operate!(::typeof(*), t1::Term, t2::AbstractTermLike)
     return t1
 end
 
+# Needed to resolve ambiguity with
+# MA.operate!(::typeof(*), ::AbstractMonomial, ::AbstractMonomialLike)
+function MA.operate!(::typeof(*), t1::Term, t2::AbstractMonomialLike)
+    MA.operate!(*, t1.coefficient, coefficient(t2))
+    MA.operate!(*, t1.monomial, monomial(t2))
+    return t1
+end
+
 function MA.operate!(::typeof(one), t::Term)
     MA.operate!(one, t.coefficient)
     MA.operate!(constant_monomial, t.monomial)

--- a/test/mutable_arithmetics.jl
+++ b/test/mutable_arithmetics.jl
@@ -1,5 +1,5 @@
-import MutableArithmetics
-const MA = MutableArithmetics
+using Test
+import MutableArithmetics as MA
 
 function all_tests(a, b, c, d, e, f, g)
     a_copy = deepcopy(a)

--- a/test/term.jl
+++ b/test/term.jl
@@ -1,5 +1,15 @@
+import MutableArithmetics as MA
+import MultivariatePolynomials as MP
+
 struct CoefNotComparable end
 Base.iszero(::CoefNotComparable) = false
+
+struct Term2{T,M} <: MP.AbstractTermLike{T}
+    monomial::M
+end
+MP.coefficient(t::Term2{T}) where {T} = 2one(T)
+MP.monomial(t) = t.monomial
+MP.term_type(::Type{Term2{T,M}}) where {T,M} = MP.Term{T,M}
 
 @testset "Term" begin
     Mod.@polyvar x
@@ -94,5 +104,22 @@ Base.iszero(::CoefNotComparable) = false
         @test t1 >= t2
         @test !(t1 < t2)
         @test t1 <= t2
+    end
+
+    @testset "MA $T" for T in [Int, BigInt]
+        M = typeof(x^2)
+        t = one(T) * x
+        s = MA.operate!!(*, t, x)
+        @test monomial(s) == x^2
+        if T == BigInt && MA.mutability(M) isa MA.IsMutable
+            @test monomial(t) == x^2
+        end
+        u = MA.operate!!(*, s, Term2{T,M}(x^3))
+        @test monomial(u) == x^5
+        @test coefficient(u) == 2
+        if T == BigInt && MA.mutability(M) isa MA.IsMutable
+            @test monomial(t) == x^5
+            @test coefficient(t) == 2
+        end
     end
 end


### PR DESCRIPTION
The upcoming release of JuMP changes how some expressions are parsed. This caused test failures for PolyJuMP and SumOfSquares: https://github.com/jump-dev/JuMP.jl/actions/runs/6042942250

The PolyJuMP error is

![image](https://github.com/JuliaAlgebra/MultivariatePolynomials.jl/assets/8177701/e5106392-df3a-4efe-b43a-94ffa4b61993)

SumOfSquares is

![image](https://github.com/JuliaAlgebra/MultivariatePolynomials.jl/assets/8177701/a0ae67a0-215a-48c1-b2e1-740987ec1625)

I assume this is the correct fix, but I'm not really sure.