### PR TITLE
Fix showing conjugate variables

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -28,7 +28,7 @@ Base.show(io::IO, p::TypesWithShow) = show(io, MIME"text/plain"(), p)
 function _show(io::IO, mime::MIME, var::AbstractVariable)
     base, indices = name_base_indices(var)
     if isconj(var)
-        for c in base
+        for c in String(base)
             print(io, c, '\u0305') # displays as overbar (̄z)
         end
     else

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -25,6 +25,15 @@
           ordinary_variable(real(x)) ==
           ordinary_variable(imag(x)) ==
           ordinary_variable(x)
+    @testset "show" begin
+        struct SymbolVar <: MP.AbstractVariable end
+        struct SymbolConjVar <: MP.AbstractVariable end
+        Base.isreal(::Union{SymbolVar,SymbolConjVar}) = false
+        MP.name_base_indices(::Union{SymbolVar,SymbolConjVar}) = (:xy, (1, 2))
+        MP.isconj(::SymbolConjVar) = true
+        @test sprint(show, SymbolVar()) == "xy₁₋₂"
+        @test sprint(show, SymbolConjVar()) == "x̅y̅₁₋₂"
+    end
     @test conj(x) != x && conj(conj(x)) == x
     @test real(x) == real(conj(x))
     @test imag(conj(x)) == -imag(x)


### PR DESCRIPTION
name_base_indices might return a Symbol instead of a String, in which case we cannot iterate over it; so make sure that we always have a String.