### PR TITLE
Promote div operation with div (not /)

### DIFF
--- a/src/division.jl
+++ b/src/division.jl
@@ -381,7 +381,7 @@ function MA.promote_operation(
     ::Type{P},
     ::Type{Q},
 ) where {T,S,P<:_APL{T},Q<:_APL{S}}
-    U = MA.promote_operation(/, T, S)
+    U = MA.promote_operation(div, T, S)
     # `promote_type(P, Q)` is needed for TypedPolynomials in case they use different variables
     return polynomial_type(promote_type(P, Q), MA.promote_operation(-, U, U))
 end


### PR DESCRIPTION
This change uses `div` in the `divrem` function, rather than `/`.

This prevents integer divison from being promoted to floats, fixing the downstream issue JuliaSymbolics/Symbolics.jl#1083.

However, I see it breaks `Multivariate gcd Rational{BigInt}` tests, so I suppose it WIP now, at best.

Is this change viable to incorporate? Sorry, my knowledge of this library is very limited!