### PR TITLE
Adjust complex-valued functionality for DP changes

### DIFF
--- a/src/complex.jl
+++ b/src/complex.jl
@@ -186,7 +186,9 @@ for fun in [:real, :imag]
                 iszero(x) &&
                     return zero(polynomial_type(x, real(coefficient_type(x))))
                 # We replace every complex variable by its decomposition into real and imaginary part
-                subst_vars = filter(Base.:! ∘ isreal, variables(x))
+                subst_vars = unique(
+                    ordinary_variable(v) for v in variables(x) if !isreal(v)
+                )
                 # To avoid a stack overflow on promote_type, we'll handle the empty case separately
                 full_version =
                     isempty(subst_vars) ? polynomial(x) :

--- a/test/commutativetests.jl
+++ b/test/commutativetests.jl
@@ -9,7 +9,7 @@ include("polynomial.jl")
 include("det.jl")
 
 include("rational.jl")
-isdefined(Mod, Symbol("@polycvar")) && include("complex.jl")
+isdefined(Mod, Symbol("@complex_polyvar")) && include("complex.jl")
 
 include("promote.jl")
 include("hash.jl")

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -10,7 +10,7 @@
     @test isreal(a^3 + 5a^2 + 4a)
     @test !isreal(a^3 + 5im * a^2 + 4a)
 
-    Mod.@polycvar x y
+    Mod.@complex_polyvar x y
     @test !isreal(x)
     @test !isrealpart(x) &&
           !isrealpart(conj(x)) &&
@@ -73,9 +73,9 @@
 
     @test subs(4x + 8y^2 - 6x^3, [x, y] => [2 + 4im, 9 - im]) ==
           (1176 - 32im) * x^0
-    @test subs(4x + 8y^2 - 6x^3, [x, conj(y)] => [2 + 4im, 9 - im]) ==
+    @test_broken subs(4x + 8y^2 - 6x^3, [x, conj(y)] => [2 + 4im, 9 - im]) ==
           (1176 + 256im) * x^0
     @test_broken subs(4x + 8y^2 - 6x^3, [x, real(y)] => [2 + 4im, 9])
-    @test subs(4x + 8y^2 - 6x^3, [x, real(y)] => [2 + 4im, 9 + 0 * x^0]) ==
+    @test_broken subs(4x + 8y^2 - 6x^3, [x, real(y)] => [2 + 4im, 9 + 0 * x^0]) ==
           1184 + 112im + 144im * imag(y) - 8imag(y)^2
 end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -73,9 +73,13 @@
 
     @test subs(4x + 8y^2 - 6x^3, [x, y] => [2 + 4im, 9 - im]) ==
           (1176 - 32im) * x^0
+    # the following are currently not supported by DP (substitution variables may
+    # only be the ordinary_variable, not a conjugate or real/imaginary part)
     @test_broken subs(4x + 8y^2 - 6x^3, [x, conj(y)] => [2 + 4im, 9 - im]) ==
-          (1176 + 256im) * x^0
+                 (1176 + 256im) * x^0
     @test_broken subs(4x + 8y^2 - 6x^3, [x, real(y)] => [2 + 4im, 9])
-    @test_broken subs(4x + 8y^2 - 6x^3, [x, real(y)] => [2 + 4im, 9 + 0 * x^0]) ==
-          1184 + 112im + 144im * imag(y) - 8imag(y)^2
+    @test_broken subs(
+        4x + 8y^2 - 6x^3,
+        [x, real(y)] => [2 + 4im, 9 + 0 * x^0],
+    ) == 1184 + 112im + 144im * imag(y) - 8imag(y)^2
 end


### PR DESCRIPTION
The latest changes in https://github.com/JuliaAlgebra/DynamicPolynomials.jl/pull/121 are reflected here.

- Macro for complex variables is now called `@complex_polyvar`
- DP does not support partial substitutions, so disable the tests